### PR TITLE
Add missing package in release mode

### DIFF
--- a/src/GummyCat/GummyCat.csproj
+++ b/src/GummyCat/GummyCat.csproj
@@ -16,6 +16,8 @@
 		<PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
 		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
 		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.5" />
+		<PackageReference Include="Avalonia.Themes.Simple" Version="11.0.5" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.5" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
 		<PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.456101" />


### PR DESCRIPTION
Some controls used are part of transitive dependencies from `Avalonia.Diagnostics`. As this package is only added in debug mode, the app fail to build in Release configuration. 

This MR explicitly add the missing dependency nuget packages.

Also with this fix, I was able to run the app in NativeAOT mode without any issue.